### PR TITLE
txData Metadata - 3.4

### DIFF
--- a/src/main/java/apoc/trigger/TransactionDataMap.java
+++ b/src/main/java/apoc/trigger/TransactionDataMap.java
@@ -33,6 +33,7 @@ public class TransactionDataMap
 
     public static final String TRANSACTION_ID = "transactionId";
     public static final String COMMIT_TIME = "commitTime";
+    public static final String METADATA = "metadata";
     public static final String CREATED_NODES = "createdNodes";
     public static final String CREATED_RELATIONSHIPS = "createdRelationships";
     public static final String DELETED_NODES = "deletedNodes";

--- a/src/main/java/apoc/trigger/Trigger.java
+++ b/src/main/java/apoc/trigger/Trigger.java
@@ -315,6 +315,7 @@ public class Trigger {
             {
                 txDataMap.put( TRANSACTION_ID, phase.equals( "after" ) ? txData.getTransactionId() : -1 );
                 txDataMap.put( COMMIT_TIME, phase.equals( "after" ) ? txData.getCommitTime() : -1 );
+                txDataMap.put( METADATA, txData.metaData() );
 
                 txDataMap.put( CREATED_NODES, createdNodeMap(txData, uidKey ) );
                 txDataMap.put( CREATED_RELATIONSHIPS, createdRelationshipsMap( txData, uidKey ) );


### PR DESCRIPTION
Adds metadata field to txData. The ONLY method to set the metadata for a transaction is through calling the procedure `dbms.setTXMetaData`.